### PR TITLE
Added main property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
 	"authors": [
 		"Luke Madera <luke.madera@gmail.com>"
 	],
+	"main" : "infinitescroll.js",
 	"description": "AngularJS infinite scroll (more robust) directive",
 	"keywords": [
 		"angular",


### PR DESCRIPTION
This allows the package to be picked up by automation tools aimed at bower_components. An example of this is the "debowerify" transform used by browserify to load bower packages using common.js syntax.
